### PR TITLE
Update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,9 @@ starting point for Ubuntu flavors.
     git submodule update --init --recursive
     ```
 
-2. Install curtin and probert:
+2. Install Subiquity's dependencies:
     ```sh
-    make -C packages/subiquity_client/subiquity gitdeps
-    ```
-
-3. Install subiquity dependencies:
-    ```sh
-    sudo packages/subiquity_client/subiquity/scripts/installdeps.sh
+    make -C packages/subiquity_client/subiquity install_deps
     ```
 
 3. [Install Flutter](https://docs.flutter.dev/get-started/install/linux)


### PR DESCRIPTION
`install_deps` seems to be a better make target as it depends on both `aptdeps` and `gitdeps` so it does it all in one go.

Plus points for using `sudo` internally for `apt` to avoid building curtin and probert as root. :)
```makefile
.PHONY: aptdeps
aptdeps:
	sudo apt update && \
	sudo apt-get install -y $(shell cat apt-deps.txt)

.PHONY: install_deps
install_deps: aptdeps gitdeps

[...]

.PHONY: gitdeps
gitdeps: curtin probert
```
https://github.com/canonical/subiquity/blob/main/Makefile#L32