### PR TITLE
chore: pin provision submodule to archive/main

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "ubuntu-desktop-provision"]
 	path = vendor/ubuntu-desktop-provision
 	url = https://github.com/canonical/ubuntu-desktop-provision.git
+	branch = archive/main


### PR DESCRIPTION
Since we're using the main branch of ubuntu-desktop-provision to work on the new provisioning workflow, the submodule in the flavor installer should point to the archived main branch (tagged 23.10.1) for the time being.